### PR TITLE
Fix comical font

### DIFF
--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -1,4 +1,3 @@
-@import "fonts";
 @import "icons";
 
 .center {

--- a/assets/_fonts.scss
+++ b/assets/_fonts.scss
@@ -40,5 +40,5 @@ $font-path: "/fonts";
 }
 
 body {
-  font-family: "Roboto", "Font Awesome 6 Sharp", "Font Awesome 6 Brands", sans-serif;
+  font-family: "Roboto", sans-serif, "Font Awesome 6 Sharp", "Font Awesome 6 Brands";
 }

--- a/assets/_fonts.scss
+++ b/assets/_fonts.scss
@@ -1,11 +1,40 @@
 $font-path: "/fonts";
 
 /*!
+ * Google Fonts
+ */
+
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local(''),
+       url('#{$font-path}/roboto-v27-latin-regular.woff2') format('woff2'),
+}
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: local(''),
+       url('#{$font-path}/roboto-v27-latin-700.woff2') format('woff2'),
+}
+
+@font-face {
+  font-family: 'Roboto Mono';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local(''),
+       url('#{$font-path}/roboto-mono-v13-latin-regular.woff2') format('woff2'),
+}
+
+/*!
  * Font Awesome Pro 6.4.0 by @fontawesome - https://fontawesome.com
  * License - https://fontawesome.com/license (Commercial License)
  * Copyright 2023 Fonticons, Inc.
  */
-
 
 @font-face {
   font-family: "Font Awesome 6 Brands";
@@ -42,3 +71,8 @@ $font-path: "/fonts";
 body {
   font-family: "Roboto", sans-serif, "Font Awesome 6 Sharp", "Font Awesome 6 Brands";
 }
+
+code {
+  font-family: 'Roboto Mono', monospace;
+}
+


### PR DESCRIPTION
Fix #17

_Note: Comical as in "Comic Sans"_

## What happened

I implemented icons using webfonts. The icon fonts are fallback fonts. So when the main font doesn't contain the glyph the icon font is used. The problem is that the theme isn't loading the Roboto font as I expected and I didn't noticed that because I have those fonts installed locally.

## Fix

Moving `sans-serif` to be preferred earlier will make browsers use their system default sans-serif font instead of the comical "Font Awesome" font.